### PR TITLE
dateparser 1.1.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,16 +12,21 @@ build:
   number: 0
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
+  entry_points:
+    - dateparser-download = dateparser_cli.cli:entrance
 
 requirements:
   build:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
-    - python
+    - python >=3.5
     - python-dateutil
     - pytz
-    - regex !=2019.02.19
+    # https://bitbucket.org/mrabarnett/mrab-regex/issues/314/import-error-no-module-named
+    - regex !=2019.02.19,!=2021.8.27,<2022.3.15
     - tzlocal
 
 test:
@@ -29,6 +34,7 @@ test:
     - pip
   commands:
     - pip check
+    - dateparser-download --help
   imports:
     - dateparser
     - dateparser.calendars
@@ -38,9 +44,11 @@ test:
 about:
   home: https://github.com/scrapinghub/dateparser
   license: BSD-3-Clause
+  license_family: BSD
   license_file: LICENSE
   summary: Date parsing library designed to parse dates from HTML pages
-
+  dev_url: https://github.com/scrapinghub/dateparser
+  doc_url: https://github.com/scrapinghub/dateparser/blob/master/README.rst
 extra:
   recipe-maintainers:
     - tacaswell

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.0.0" %}
+{% set version = "1.1.1" %}
 
 package:
   name: dateparser
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/d/dateparser/dateparser-{{ version }}.tar.gz
-  sha256: 159cc4e01a593706a15cd4e269a0b3345edf3aef8bf9278a57dac8adf5bf1e4a
+  sha256: 038196b1f12c7397e38aad3d61588833257f6f552baa63a1499e6987fa8d42d9
 
 build:
   number: 0


### PR DESCRIPTION
Update dateparser to 1.1.1

Bug Tracker: new open issues https://github.com/scrapinghub/dateparser/issues
Changelog: https://github.com/scrapinghub/dateparser/blob/v1.1.1/HISTORY.rst
Upstream license:  License file:  https://github.com/scrapinghub/dateparser/blob/master/LICENSE
Upstream setup.py:  https://github.com/scrapinghub/dateparser/blob/v1.1.1/setup.py

The package dateparser is mentioned inside the packages:
arrow |

Actions:
1. Add entry_pionts 
2. Add missing setuptools and wheel
3. Use python >=3.5 in run
4. Fix regex pinnings
5. Add commands: `dateparser-download --help`
6. Add license_family
7. Add dev and doc urls

Result:
- all-succeeded