### PR TITLE
update to version 1.1.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.1.1" %}
+{% set version = "1.1.4" %}
 
 package:
   name: dateparser
@@ -6,12 +6,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/d/dateparser/dateparser-{{ version }}.tar.gz
-  sha256: 038196b1f12c7397e38aad3d61588833257f6f552baa63a1499e6987fa8d42d9
+  sha256: 73ec6e44a133c54076ecf9f9dc0fbe3dd4831f154f977ff06f53114d57c5425e
 
 build:
   number: 0
-  noarch: python
   script: {{ PYTHON }} -m pip install . -vv
+  skip: True  # [py<36]
   entry_points:
     - dateparser-download = dateparser_cli.cli:entrance
 
@@ -22,7 +22,7 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python >=3.5
+    - python
     - python-dateutil
     - pytz
     # https://bitbucket.org/mrabarnett/mrab-regex/issues/314/import-error-no-module-named
@@ -47,6 +47,8 @@ about:
   license_family: BSD
   license_file: LICENSE
   summary: Date parsing library designed to parse dates from HTML pages
+  description: |
+    Python parser for human readable dates.
   dev_url: https://github.com/scrapinghub/dateparser
   doc_url: https://github.com/scrapinghub/dateparser/blob/master/README.rst
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv
-  skip: True  # [py<36]
+  skip: True  # [py<37]
   entry_points:
     - dateparser-download = dateparser_cli.cli:entrance
 


### PR DESCRIPTION
`dateparser` version `1.1.4`

1. - [x] Check the upstream 
https://github.com/scrapinghub/dateparser/tree/v1.1.4

2. - [x] Check the pinnings

`python 3.7 pinning`
https://github.com/scrapinghub/dateparser/blob/v1.1.4/setup.py#L44

3. - [x] Check the changelogs
https://github.com/scrapinghub/dateparser/blob/v1.1.4/HISTORY.rst

currently the changes are mainly bug fixes and improvements to the current application. There are no breaking changes mentioned

4. - [x] Additional research
https://github.com/conda-forge/dateparser-feedstock/issues
There are currenly no open issues mentioned in the upstream

5. - [x] Verify the `dev_url`
https://github.com/scrapinghub/dateparser

6. - [x] Verify the `doc_url`
https://github.com/scrapinghub/dateparser/blob/master/README.rst

7. - [x] License is `spdx` compliant
BSD-3-Clause

8. - [x] License family is present
BSD

9. -[x] Verify that the `build_number` is correct 

10. - [x] Verify if the package needs `setuptools`
setuptools

11. - [x] Verify if the package needs `wheel`
wheel

12. - [x] `pip` in the test section
pip

13. - [x] Veriy the test section

14. - [x] Verify if the package is `architecture` specific or `Noarch`

15. - [x] Verify that private modules are not mentioned on the recipe For example: (_private_module)

## Results:

---

Based on the research findings and the results we can conclude
that it is safe to update `dateparser` to version `1.1.4`
