### PR TITLE
v1.1.8

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.1.4" %}
+{% set version = "1.1.8" %}
 
 package:
   name: dateparser
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/d/dateparser/dateparser-{{ version }}.tar.gz
-  sha256: 73ec6e44a133c54076ecf9f9dc0fbe3dd4831f154f977ff06f53114d57c5425e
+  sha256: 86b8b7517efcc558f085a142cdb7620f0921543fcabdb538c8a4c4001d8178e3
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - python-dateutil
     - pytz
     # https://bitbucket.org/mrabarnett/mrab-regex/issues/314/import-error-no-module-named
-    - regex !=2019.02.19,!=2021.8.27,<2022.3.15
+    - regex !=2019.02.19,!=2021.8.27
     - tzlocal
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   skip: True  # [py<37]
   entry_points:
     - dateparser-download = dateparser_cli.cli:entrance

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ build:
     - dateparser-download = dateparser_cli.cli:entrance
 
 requirements:
-  build:
+  host:
     - python
     - pip
     - setuptools


### PR DESCRIPTION
upstream: https://github.com/scrapinghub/dateparser/blob/v1.1.8/
setup.py: https://github.com/scrapinghub/dateparser/blob/v1.1.8/setup.py
license: https://github.com/scrapinghub/dateparser/blob/v1.1.8/LICENSE

## Notes
- Adds python 3.11 support
