### PR TITLE
dateparser 1.3.0 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,20 +1,20 @@
 {% set name = "dateparser" %}
-{% set version = "1.2.2" %}
+{% set version = "1.3.0" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 986316f17cb8cdc23ea8ce563027c5ef12fc725b6fb1d137c14ca08777c5ecf7
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 5bccf5d1ec6785e5be71cc7ec80f014575a09b4923e762f850e57443bddbf1a5
 
 build:
   number: 0
-  skip: True  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
   entry_points:
     - dateparser-download = dateparser_cli.cli:entrance
+  skip: true  # [py<310]
 
 requirements:
   host:
@@ -28,11 +28,10 @@ requirements:
     - pytz >=2024.2
     - regex >=2024.9.11
     - tzlocal >=0.2
-
   run_constrained:
     - convertdate >=2.2.1
     - fasttext >=0.9.1
-    - numpy >=1.19.3,<2
+    - numpy >=1.22.0,<2
     - langdetect >=1.0.0
 
 # Skipping tests that require optional extras (calendars, fasttext, langdetect),
@@ -44,18 +43,6 @@ requirements:
 test:
   source_files:
     - tests
-  requires:
-    - pip
-    - pytest
-    - parameterized
-    - convertdate >=2.2.1
-  commands:
-    - pip check
-    - dateparser-download --help
-    - pytest tests -v  # [not win]
-    # Disable import test_date.py on Windows. This test use time.tzset() POSIX call 
-    - pytest tests -v --ignore=tests/test_date.py {{ deselect_tests }}  # [win]
-
   imports:
     - dateparser
     - dateparser.calendars
@@ -77,6 +64,18 @@ test:
     - dateparser.timezone_parser
     - dateparser.utils
     - dateparser.utils.strptime
+  commands:
+    - pip check
+    - dateparser-download --help
+    - pytest tests -v  # [not win]
+    # Disable import test_date.py on Windows. This test use time.tzset() POSIX call 
+    - pytest tests -v --ignore=tests/test_date.py {{ deselect_tests }}  # [win]
+  requires:
+    - pip
+    - pytest
+    - parameterized
+    - convertdate >=2.2.1
+  
 
 about:
   home: https://github.com/scrapinghub/dateparser


### PR DESCRIPTION
dateparser 1.3.0 

**Destination channel:** Defaults

### Links

- [PKG-12396]
- dev_url:        https://github.com/scrapinghub/dateparser/tree/v1.3.0
- conda_forge:    https://github.com/conda-forge/dateparser-feedstock
- pypi:           https://pypi.org/project/dateparser/1.3.0
- pypi inspector: https://inspector.pypi.io/project/dateparser/1.3.0

### Explanation of changes:

- new version number


[PKG-12396]: https://anaconda.atlassian.net/browse/PKG-12396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ